### PR TITLE
Fix Mac OS X Rendering

### DIFF
--- a/lib/raycaster/renderer.ex
+++ b/lib/raycaster/renderer.ex
@@ -165,7 +165,7 @@ defmodule Raycaster.Renderer do
              point = Line.point2(ray)
              {round(point.x), round(point.y)}
            end)
-      IO.inspect outer_polygon_points
+      # IO.inspect outer_polygon_points
       :wxDC.drawPolygon(dc, outer_polygon_points)
     end
     draw(state.canvas, state.bitmap, fun)
@@ -293,7 +293,7 @@ defmodule Raycaster.Renderer do
     memory_dc = :wxMemoryDC.new(bitmap)
     fun.(memory_dc)
 
-    cdc = :wxWindowDC.new(canvas)
+    cdc = :wxClientDC.new(canvas)
     :wxDC.blit(
       cdc,
       {0,0},


### PR DESCRIPTION
Josh, thanks again for our chat today.  I'm already learning a ton from reading through the `:wx.demo` code!

As a small means of thanks, this is enough of a change to get Raycaster rendering on my machine.

It seems [we're meant to be use `:wxClientDC` anytime we're rendering outside of a paint callback](http://docs.wxwidgets.org/2.8.12/wx_wxclientdc.html).  [This example file](https://github.com/erlang/otp/blob/maint/lib/wx/examples/demo/ex_canvas_paint.erl) has been pretty helpful to me in figuring stuff out.  [This is where it's handling the paint callback](https://github.com/erlang/otp/blob/maint/lib/wx/examples/demo/ex_canvas_paint.erl#L102-L106), so it uses `:wxPaintDC`.  However, [this function is called from non-paint event callbacks](https://github.com/erlang/otp/blob/maint/lib/wx/examples/demo/ex_canvas_paint.erl#L233-L244), like mouse motion callbacks.  That's the difference between `redraw()` and `draw()` in this code.

After this fix, I do have some lag in the drawing.  It seems like the calculations drag the rendering down on Mac OS X.  Raising the `@timer_interval` resolves this, so I'm pretty sure that's not a platform specific issue.
